### PR TITLE
Improve docker-compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DOMAIN=workmate.example.com
+CLIENT_ID=your_client_id
+CLIENT_SECRET=your_secret
+VERIFY_SSL=true
+CERTBOT_EMAIL=admin@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Workmate Compose Setup
+
+This repository contains a multi-service setup for the Workmate project. To start the stack you need a `.env` file with your environment specific configuration.
+
+```
+cp .env.example .env
+# adjust values inside .env
+```
+
+Build and start all services via Docker Compose:
+
+```
+docker-compose up --build
+```
+
+

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -2,9 +2,13 @@ FROM python:3.10-slim
 
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+RUN useradd -m appuser && chown -R appuser /app
+
+USER appuser
 
 EXPOSE 5001
 CMD ["python", "auth_service.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3.8'
 
 x-defaults: &default-env
+  env_file:
+    - .env
   environment:
     - DOMAIN=${DOMAIN}
     - CLIENT_ID=${CLIENT_ID}
@@ -19,26 +21,26 @@ services:
       - license-service
       - redis
     restart: unless-stopped
+    networks:
+      - backend
 
   auth-service:
     <<: *default-env
-    image: registry.gitlab.com/marc.haenni/semesterarbeit-3-marc-haenni/auth-service:latest
+    build: ./auth-service
     ports:
       - "5001:5001"
     environment:
       - FRONTEND_URL=https://${DOMAIN}/
       - REDIRECT_URI=https://${DOMAIN}/getAToken
-      - DOMAIN=${DOMAIN}
-      - CLIENT_ID=${CLIENT_ID}
-      - CLIENT_SECRET=${CLIENT_SECRET}
-      - VERIFY_SSL=${VERIFY_SSL}
     depends_on:
       - redis
     restart: unless-stopped
+    networks:
+      - backend
 
   file-service:
     <<: *default-env
-    image: registry.gitlab.com/marc.haenni/semesterarbeit-3-marc-haenni/file-service:latest
+    build: ./file-service
     ports:
       - "5002:5002"
     volumes:
@@ -46,22 +48,30 @@ services:
     depends_on:
       - redis
     restart: unless-stopped
+    networks:
+      - backend
 
   license-service:
     <<: *default-env
-    image: registry.gitlab.com/marc.haenni/semesterarbeit-3-marc-haenni/license-service:latest
+    build: ./license-service
     ports:
       - "5003:5003"
     depends_on:
       - redis
     restart: unless-stopped
+    networks:
+      - backend
 
   redis:
     <<: *default-env
     image: redis:6.2
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
     restart: unless-stopped
+    networks:
+      - backend
 
   ma-proxy:
     <<: *default-env
@@ -70,6 +80,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    command: >
+      /bin/sh -c "envsubst '$$DOMAIN' < /etc/nginx/user_conf.d/nginx-proxy.prod.conf > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
     environment:
       - CERTBOT_EMAIL=marc.haenni@hotmail.ch
       - CERTBOT_DOMAINS=${DOMAIN}
@@ -82,7 +94,13 @@ services:
       - auth-service
       - file-service
       - license-service
+    networks:
+      - backend
 
 volumes:
   nginx_secrets:
+  redis_data:
+
+networks:
+  backend:
 

--- a/file-service/Dockerfile
+++ b/file-service/Dockerfile
@@ -2,11 +2,14 @@ FROM python:3.10-slim
 
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN mkdir -p /app/uploads
+RUN mkdir -p /app/uploads && \
+    useradd -m appuser && chown -R appuser /app
+
+USER appuser
 
 EXPOSE 5002
 CMD ["python", "file_service.py"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,5 +10,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Kopiere den gesamten App-Code inkl. templates
 COPY . .
 
+RUN useradd -m appuser && chown -R appuser /app
+
+USER appuser
+
 # Flask wird auf 0.0.0.0:5000 ausgeführt
 CMD ["python", "app.py"]

--- a/license-service/Dockerfile
+++ b/license-service/Dockerfile
@@ -2,9 +2,13 @@ FROM python:3.10-slim
 
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+RUN useradd -m appuser && chown -R appuser /app
+
+USER appuser
 
 EXPOSE 5003
 CMD ["python", "license_service.py"]

--- a/user_conf.d/nginx-proxy.prod.conf
+++ b/user_conf.d/nginx-proxy.prod.conf
@@ -2,11 +2,11 @@ server {
     listen 443 ssl default_server reuseport;
     listen [::]:443 ssl default_server reuseport;
 
-    server_name workmate.m-haenni.ch;
+    server_name ${DOMAIN};
 
-    ssl_certificate         /etc/letsencrypt/live/workmate.m-haenni.ch/fullchain.pem;
-    ssl_certificate_key     /etc/letsencrypt/live/workmate.m-haenni.ch/privkey.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/workmate.m-haenni.ch/chain.pem;
+    ssl_certificate         /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/${DOMAIN}/chain.pem;
     ssl_dhparam /etc/letsencrypt/dhparams/dhparam.pem;
 
     # Haupt-Frontend
@@ -70,7 +70,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name workmate.m-haenni.ch;
+server_name ${DOMAIN};
 
     location / {
         return 301 https://$host$request_uri;


### PR DESCRIPTION
## Summary
- parameterize `nginx` config using `${DOMAIN}` and render it using `envsubst`
- build images from local Dockerfiles and consolidate env vars via `.env` file
- add persistent Redis volume and a dedicated network
- tighten Dockerfiles with non-root users and `--no-cache-dir` installs
- add example `.env` and basic README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b0a20c8cc8325bb820a3016dbde04