### PR TITLE
Add Teams Direct Routing service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,17 @@ services:
     networks:
       - backend
 
+  teamsdirectrouting-service:
+    <<: *default-env
+    build: ./teamsdirectrouting-service
+    ports:
+      - "5005:5005"
+    depends_on:
+      - redis
+    restart: unless-stopped
+    networks:
+      - backend
+
   redis:
     <<: *default-env
     image: redis:6.2
@@ -106,6 +117,7 @@ services:
       - file-service
       - license-service
       - group-service
+      - teamsdirectrouting-service
     networks:
       - backend
 

--- a/frontend/templates/dashboard.html
+++ b/frontend/templates/dashboard.html
@@ -28,6 +28,16 @@
                         📦 Lizenzverwaltung starten
                     </a>
                 </li>
+                <li>
+                    <a href="/group" class="inline-block w-full px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition">
+                        👥 Gruppenverwaltung starten
+                    </a>
+                </li>
+                <li>
+                    <a href="/directrouting" class="inline-block w-full px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition">
+                        ☎️ Teams Direct Routing
+                    </a>
+                </li>
             </ul>
         </div>
 

--- a/frontend/templates/directrouting.html
+++ b/frontend/templates/directrouting.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Teams Direct Routing</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-800 font-sans">
+
+<div class="max-w-4xl mx-auto p-6 mt-10 bg-white rounded-xl shadow-md space-y-6">
+    <h1 class="text-2xl font-bold text-center">☎️ Teams Direct Routing</h1>
+
+    <div class="border-t pt-6">
+        <h2 class="text-lg font-semibold mb-4">Rufnummernzuweisung via CSV/Excel</h2>
+        <form action="/assign_directrouting" method="post" enctype="multipart/form-data" class="space-y-4">
+            <div>
+                <label for="file" class="block mb-1 text-sm font-medium">Datei hochladen</label>
+                <input type="file" id="file" name="file" accept=".csv,.xls,.xlsx" required
+                       class="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none">
+            </div>
+
+            <button type="submit" class="inline-block px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition">Rufnummern zuweisen</button>
+        </form>
+    </div>
+
+    <div class="text-center pt-4">
+        <a href="/dashboard" class="text-sm text-blue-600 hover:underline">← Zurück zum Dashboard</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/frontend/templates/directrouting_result.html
+++ b/frontend/templates/directrouting_result.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Ergebnis Direct Routing</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-800 font-sans">
+
+<div class="max-w-4xl mx-auto p-6 mt-10 bg-white rounded-xl shadow-md space-y-6">
+    <h2 class="text-2xl font-bold text-center">📋 Ergebnis der Rufnummernzuweisung</h2>
+
+    {% if error %}
+        <div class="text-red-600 text-center font-medium">{{ error }}</div>
+    {% else %}
+        <div class="overflow-x-auto">
+            <table class="min-w-full table-auto border border-gray-300">
+                <thead class="bg-gray-100">
+                <tr>
+                    <th class="px-4 py-2 text-left">Benutzer (UPN)</th>
+                    <th class="px-4 py-2 text-left">Nummer</th>
+                    <th class="px-4 py-2 text-left">Status</th>
+                    <th class="px-4 py-2 text-left">Typ</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                {% for result in results %}
+                    <tr>
+                        <td class="px-4 py-2">{{ result.upn }}</td>
+                        <td class="px-4 py-2">{{ result.phone }}</td>
+                        <td class="px-4 py-2">{{ result.status }}</td>
+                        <td class="px-4 py-2">{{ result.target }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
+    <div class="text-center pt-4">
+        <a href="/directrouting" class="text-sm text-blue-600 hover:underline">← Zurück</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/frontend/templates/group.html
+++ b/frontend/templates/group.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Gruppenverwaltung</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-800 font-sans">
+
+<div class="max-w-4xl mx-auto p-6 mt-10 bg-white rounded-xl shadow-md space-y-6">
+    <h1 class="text-2xl font-bold text-center">👥 Gruppenverwaltung</h1>
+
+    <div class="overflow-x-auto">
+        <table class="min-w-full table-auto border border-gray-300">
+            <thead class="bg-gray-100">
+            <tr>
+                <th class="px-4 py-2 text-left">Gruppe</th>
+            </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+            {% for name, id in groups.items() %}
+                <tr>
+                    <td class="px-4 py-2">{{ name }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="border-t pt-6">
+        <h2 class="text-lg font-semibold mb-4">Gruppenzuweisung via CSV/Excel</h2>
+        <form action="/assign_group" method="post" enctype="multipart/form-data" class="space-y-4">
+            <div>
+                <label for="file" class="block mb-1 text-sm font-medium">Datei hochladen</label>
+                <input type="file" id="file" name="file" accept=".csv,.xls,.xlsx" required
+                       class="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none">
+            </div>
+
+            <div>
+                <label for="group_name" class="block mb-1 text-sm font-medium">Gruppe auswählen</label>
+                <select id="group_name" name="group_name" required class="block w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm">
+                    {% for name in groups.keys() %}
+                        <option value="{{ name }}">{{ name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <button type="submit" class="inline-block px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition">Gruppenzuweisung starten</button>
+        </form>
+    </div>
+
+    <div class="text-center pt-4">
+        <a href="/dashboard" class="text-sm text-blue-600 hover:underline">← Zurück zum Dashboard</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/frontend/templates/group_result.html
+++ b/frontend/templates/group_result.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Ergebnis Gruppenzuweisung</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-800 font-sans">
+
+<div class="max-w-4xl mx-auto p-6 mt-10 bg-white rounded-xl shadow-md space-y-6">
+    <h2 class="text-2xl font-bold text-center">📋 Ergebnis der Gruppenzuweisung für <span class="text-green-600">{{ group_name }}</span></h2>
+
+    {% if error %}
+        <div class="text-red-600 text-center font-medium">{{ error }}</div>
+    {% else %}
+        <div class="overflow-x-auto">
+            <table class="min-w-full table-auto border border-gray-300">
+                <thead class="bg-gray-100">
+                <tr>
+                    <th class="px-4 py-2 text-left">Benutzer (UPN)</th>
+                    <th class="px-4 py-2 text-left">Status</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                {% for result in results %}
+                    <tr>
+                        <td class="px-4 py-2">{{ result.upn }}</td>
+                        <td class="px-4 py-2">{{ result.status }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
+    <div class="text-center pt-4">
+        <a href="/group" class="text-sm text-blue-600 hover:underline">← Zurück zur Gruppenübersicht</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/teamsdirectrouting-service/Dockerfile
+++ b/teamsdirectrouting-service/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN useradd -m appuser && chown -R appuser /app
+
+USER appuser
+
+EXPOSE 5005
+CMD ["python", "teamsdirectrouting_service.py"]

--- a/teamsdirectrouting-service/requirements.txt
+++ b/teamsdirectrouting-service/requirements.txt
@@ -1,0 +1,7 @@
+flask
+requests
+flask-session
+PyJWT
+pandas
+openpyxl
+xlrd

--- a/teamsdirectrouting-service/teamsdirectrouting_service.py
+++ b/teamsdirectrouting-service/teamsdirectrouting_service.py
@@ -1,0 +1,127 @@
+from flask import Flask, request, jsonify
+import requests
+import jwt
+import datetime
+import pandas as pd
+import re
+import os
+
+app = Flask(__name__)
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+
+
+def get_auth_headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def extract_token(auth_header):
+    if auth_header and auth_header.lower().startswith('bearer '):
+        return auth_header[7:]
+    return None
+
+
+def token_is_expired(token: str) -> bool:
+    """Check expiry of JWT without verifying signature."""
+    try:
+        decoded = jwt.decode(token, options={"verify_signature": False})
+        exp = decoded.get("exp")
+        if exp is None:
+            return True
+        expire_time = datetime.datetime.utcfromtimestamp(exp)
+        return expire_time < datetime.datetime.utcnow()
+    except Exception:
+        return True
+
+
+def parse_file(file):
+    file_ext = os.path.splitext(file.filename)[1].lower().strip()
+    if file_ext == '.csv':
+        df = pd.read_csv(file)
+    elif file_ext in ['.xls', '.xlsx']:
+        df = pd.read_excel(file, engine='openpyxl')
+    else:
+        raise ValueError(f"Unsupported file format: {file_ext}")
+
+    upn_pattern = re.compile(r'[\w\.-]+@[\w\.-]+\.\w+')
+    phone_pattern = re.compile(r'^\+?\d+(?:\s?\d+)*$')
+
+    pairs = []
+    for _, row in df.iterrows():
+        upn = None
+        phone = None
+        for value in row.dropna():
+            val = str(value).strip()
+            if upn is None and upn_pattern.fullmatch(val):
+                upn = val
+            if phone is None and phone_pattern.fullmatch(val.replace(' ', '')):
+                phone = val
+        if upn and phone:
+            pairs.append({'upn': upn, 'phone': phone})
+    return pairs
+
+
+def user_has_teams_phone(user_id, token):
+    response = requests.get(
+        f"{GRAPH_API_BASE}/users/{user_id}/licenseDetails",
+        headers=get_auth_headers(token)
+    )
+    if response.status_code != 200:
+        return False
+    for lic in response.json().get('value', []):
+        for plan in lic.get('servicePlans', []):
+            if plan.get('servicePlanName') == 'MCOEV' and plan.get('provisioningStatus') == 'Success':
+                return True
+    return False
+
+
+@app.route('/assign', methods=['POST'])
+def assign_numbers():
+    auth_header = request.headers.get('Authorization')
+    token = extract_token(auth_header)
+
+    if not token or token_is_expired(token):
+        return jsonify({'error': 'Token fehlt oder abgelaufen'}), 401
+
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'Datei fehlt'}), 400
+
+    try:
+        pairs = parse_file(file)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+    results = []
+    for pair in pairs:
+        upn = pair['upn']
+        phone = pair['phone']
+        user_res = requests.get(f"{GRAPH_API_BASE}/users/{upn}", headers=get_auth_headers(token))
+        if user_res.status_code != 200:
+            results.append({'upn': upn, 'phone': phone, 'status': 'Benutzer nicht gefunden'})
+            continue
+
+        user_data = user_res.json()
+        user_id = user_data.get('id')
+        user_type = 'ResourceAccount' if user_data.get('userType') == 'Application' else 'User'
+
+        if not user_has_teams_phone(user_id, token):
+            results.append({'upn': upn, 'phone': phone, 'status': 'Keine Teams Phone Lizenz', 'target': user_type})
+            continue
+
+        patch_res = requests.patch(
+            f"{GRAPH_API_BASE}/users/{user_id}",
+            headers={**get_auth_headers(token), 'Content-Type': 'application/json'},
+            json={'businessPhones': [phone]}
+        )
+        if patch_res.status_code in (200, 204):
+            results.append({'upn': upn, 'phone': phone, 'status': 'Nummer zugewiesen', 'target': user_type})
+        else:
+            detail = patch_res.json().get('error', {}).get('message', patch_res.status_code)
+            results.append({'upn': upn, 'phone': phone, 'status': f'Fehler: {detail}', 'target': user_type})
+
+    return jsonify({'results': results})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5005)

--- a/teamsdirectrouting-service/tests/test_directrouting.py
+++ b/teamsdirectrouting-service/tests/test_directrouting.py
@@ -1,0 +1,20 @@
+import sys
+import os
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from teamsdirectrouting_service import app as flask_app
+
+flask_app.config["TESTING"] = True
+flask_app.config["SECRET_KEY"] = "test"
+
+@pytest.fixture
+def client():
+    with flask_app.test_client() as client:
+        yield client
+
+
+def test_assign_unauthorized(client):
+    response = client.post("/assign")
+    assert response.status_code == 401

--- a/user_conf.d/nginx-proxy.prod.conf
+++ b/user_conf.d/nginx-proxy.prod.conf
@@ -24,6 +24,9 @@ server {
     location = /groups {
         return 301 $scheme://$host/groups/;
     }
+    location = /directrouting {
+        return 301 $scheme://$host/directrouting/;
+    }
     location = /auth {
         return 301 $scheme://$host/auth/;
     }
@@ -66,6 +69,11 @@ server {
     # Group-Service
     location /groups/ {
         proxy_pass http://group-service:5004/;
+    }
+
+    # Teams Direct Routing Service
+    location /directrouting/ {
+        proxy_pass http://teamsdirectrouting-service:5005/;
     }
 
     # License-Service


### PR DESCRIPTION
## Summary
- add TeamsDirectRouting service for assigning phone numbers
- proxy new service via nginx and docker-compose
- integrate group and direct routing workflows into frontend
- add templates for groups and direct routing
- add simple unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b17d2066883258fa18f9acb9e0422