### PR TITLE
Add GitHub Actions CI/CD for EC2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r auth-service/requirements.txt
+          pip install -r file-service/requirements.txt
+          pip install -r frontend/requirements.txt
+          pip install -r group-service/requirements.txt
+          pip install -r license-service/requirements.txt
+          pip install -r teamsdirectrouting-service/requirements.txt
+
+      - name: Run tests
+        run: pytest */tests
+
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
+
+      - name: Deploy to EC2 via SSH
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} <<'SSH'
+            set -e
+            cd ~/workmate
+            git pull
+            docker-compose up -d --build
+          SSH

--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ docker-compose up --build
 ```
 
 
+
+## CI/CD Deployment on AWS EC2
+
+This project includes a GitHub Actions workflow that builds the services, runs the tests and deploys the stack to an EC2 instance via SSH.
+
+### Setup
+
+1. Prepare an EC2 instance with Docker and `docker-compose` installed.
+2. Clone this repository on the server, e.g. into `~/workmate`.
+3. In your GitHub repository settings create the following secrets:
+   - `EC2_HOST` – Public hostname or IP of the EC2 server.
+   - `EC2_USER` – SSH username.
+   - `EC2_SSH_KEY` – Private key with access to the server.
+4. Push changes to the `main` branch. The workflow defined in `.github/workflows/deploy.yml` will run the tests and update the running stack on the EC2 instance.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and deploy to EC2 via SSH
- document how to set up the pipeline in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685be1ca760c8325a6e5c32a9eafae96